### PR TITLE
Add rake to development dependancy

### DIFF
--- a/reditor.gemspec
+++ b/reditor.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'tapp',  '>= 1.3.1'
   gem.add_development_dependency 'rspec', '>= 2.10.0'
+  gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
There is `Rakefile`, but `rake` does not exist.
